### PR TITLE
Add linux/debian update scripts and README

### DIFF
--- a/linux/debian/README.md
+++ b/linux/debian/README.md
@@ -1,0 +1,35 @@
+# Debian / Ubuntu update scripts
+
+This folder contains simple, well-documented scripts for performing package updates on Debian-based systems (Debian, Ubuntu, and derivatives).
+
+Files:
+
+- `system-update.sh`: Safe, minimal updates focused on security/unattended upgrades. Intended for cron or periodic runs.
+- `full-update.sh`: Full system upgrade (dist-upgrade), optionally reboots if requested. Intended for interactive or admin-run updates.
+
+Why a `linux/debian` folder?
+
+Keeping distribution-specific scripts under `linux/<distro>` makes it easier to add RedHat/CentOS (`linux/redhat`) or SUSE (`linux/suse`) variants later. It also makes CI/automation targeting easier.
+
+Usage examples:
+
+Non-interactive system update (good for cron):
+
+    sudo bash linux/debian/system-update.sh
+
+Full upgrade with automatic yes and reboot if required:
+
+    sudo bash linux/debian/full-update.sh --yes --reboot
+
+Notes and recommendations:
+
+- Run these scripts as root (they auto-elevate with `sudo` if needed).
+- Place cron jobs or systemd timers that call `system-update.sh` for periodic unattended updates.
+- Consider installing `unattended-upgrades` for better security-only patch management.
+- For servers, prefer `system-update.sh` via a scheduled job; reserve `full-update.sh` for maintenance windows.
+
+Conventions and next steps:
+
+- Add `linux/redhat` and `linux/suse` directories for RPM-based systems.
+- Optionally provide a `setup` script to install `unattended-upgrades` and configure automatic security patches.
+- Add tests or a `--dry-run` mode if you want to validate the behavior without making changes.

--- a/linux/debian/full-update.sh
+++ b/linux/debian/full-update.sh
@@ -79,7 +79,7 @@ main() {
 
   echo "Cleaning up..." | tee -a "$LOG_FILE"
   apt-get autoremove -y 2>&1 | tee -a "$LOG_FILE" || true
-  apt-get autoclean -y 2>&1 | tee -a "$LOG_FILE" || true
+  apt-get autoclean 2>&1 | tee -a "$LOG_FILE" || true
 
   if [ -f /var/run/reboot-required ] || [ -f /var/run/reboot-required.pkgs ]; then
     echo "Reboot required after updates" | tee -a "$LOG_FILE"

--- a/linux/debian/full-update.sh
+++ b/linux/debian/full-update.sh
@@ -60,7 +60,6 @@ main() {
   done
 
   ensure_root
-  mkdir -p "$(dirname "$LOG_FILE")"
   echo "$(timestamp) - START full-update" | tee -a "$LOG_FILE"
 
   if ! wait_for_apt_lock; then

--- a/linux/debian/full-update.sh
+++ b/linux/debian/full-update.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# full-update.sh
+# Perform a full system upgrade including kernel packages and optional distribution upgrades.
+# - requires root (auto-elevate via sudo)
+# - prompts before doing a dist-upgrade or reboot unless --yes is provided
+# - creates a simple transaction log in /var/log/full-update.log
+
+LOG_FILE="/var/log/full-update.log"
+
+usage() {
+  cat <<EOF
+Usage: $0 [--yes|-y] [--reboot|-r]
+
+Options:
+  -y, --yes    Run non-interactively and assume yes to prompts
+  -r, --reboot Reboot automatically if required after updates
+  -h, --help   Show this help
+EOF
+}
+
+ensure_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Re-running as root using sudo..."
+    exec sudo bash "$0" "$@"
+  fi
+}
+
+timestamp() { date --rfc-3339=seconds; }
+
+WAIT_MAX=30
+
+wait_for_apt_lock() {
+  local tries=0
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    if [ "$tries" -ge "$WAIT_MAX" ]; then
+      echo "Timed out waiting for apt/dpkg locks" | tee -a "$LOG_FILE"
+      return 1
+    fi
+    echo "Waiting for apt/dpkg lock to be released... (attempt $((tries+1)))" | tee -a "$LOG_FILE"
+    sleep 2
+    tries=$((tries+1))
+  done
+  return 0
+}
+
+main() {
+  local ASSUME_YES=0
+  local AUTO_REBOOT=0
+
+  # parse args
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      -y|--yes) ASSUME_YES=1; shift ;;
+      -r|--reboot) AUTO_REBOOT=1; shift ;;
+      -h|--help) usage; exit 0 ;;
+      *) echo "Unknown arg: $1"; usage; exit 2 ;;
+    esac
+  done
+
+  ensure_root
+  mkdir -p "$(dirname "$LOG_FILE")"
+  echo "$(timestamp) - START full-update" | tee -a "$LOG_FILE"
+
+  if ! wait_for_apt_lock; then
+    echo "Failed to acquire apt locks" | tee -a "$LOG_FILE"
+    exit 2
+  fi
+
+  echo "Updating package lists..." | tee -a "$LOG_FILE"
+  apt-get update 2>&1 | tee -a "$LOG_FILE"
+
+  echo "Performing full upgrade (may install/remove packages)..." | tee -a "$LOG_FILE"
+  if [ "$ASSUME_YES" -eq 1 ]; then
+    DEBIAN_FRONTEND=noninteractive apt-get dist-upgrade -y -o Dpkg::Options::='--force-confdef' -o Dpkg::Options::='--force-confold' 2>&1 | tee -a "$LOG_FILE"
+  else
+    apt-get dist-upgrade 2>&1 | tee -a "$LOG_FILE"
+  fi
+
+  echo "Cleaning up..." | tee -a "$LOG_FILE"
+  apt-get autoremove -y 2>&1 | tee -a "$LOG_FILE" || true
+  apt-get autoclean -y 2>&1 | tee -a "$LOG_FILE" || true
+
+  if [ -f /var/run/reboot-required ] || [ -f /var/run/reboot-required.pkgs ]; then
+    echo "Reboot required after updates" | tee -a "$LOG_FILE"
+    if [ "$AUTO_REBOOT" -eq 1 ]; then
+      echo "Rebooting now by request" | tee -a "$LOG_FILE"
+      reboot
+    else
+      echo "Run 'sudo reboot' to restart or re-run with --reboot to reboot automatically." | tee -a "$LOG_FILE"
+    fi
+  fi
+
+  echo "$(timestamp) - END full-update" | tee -a "$LOG_FILE"
+}
+
+main "$@"

--- a/linux/debian/full-update.sh
+++ b/linux/debian/full-update.sh
@@ -33,7 +33,7 @@ WAIT_MAX=30
 
 wait_for_apt_lock() {
   local tries=0
-  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
     if [ "$tries" -ge "$WAIT_MAX" ]; then
       echo "Timed out waiting for apt/dpkg locks" | tee -a "$LOG_FILE"
       return 1

--- a/linux/debian/system-update.sh
+++ b/linux/debian/system-update.sh
@@ -37,7 +37,6 @@ timestamp() { date --rfc-3339=seconds; }
 main() {
   ensure_root
 
-  mkdir -p "$(dirname "$LOG_FILE")"
   echo "$(timestamp) - START system-update" | tee -a "$LOG_FILE"
 
   if ! wait_for_apt_lock; then

--- a/linux/debian/system-update.sh
+++ b/linux/debian/system-update.sh
@@ -20,7 +20,7 @@ wait_for_apt_lock() {
   local tries=0
   local max=30
   local sleep_sec=2
-  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
     if [ "$tries" -ge "$max" ]; then
       echo "Timed out waiting for apt/dpkg locks" | tee -a "$LOG_FILE"
       return 1

--- a/linux/debian/system-update.sh
+++ b/linux/debian/system-update.sh
@@ -45,7 +45,7 @@ main() {
   fi
 
   echo "Running apt-get update..." | tee -a "$LOG_FILE"
-  apt-get update -y 2>&1 | tee -a "$LOG_FILE"
+  apt-get update 2>&1 | tee -a "$LOG_FILE"
 
   echo "Running unattended-upgrades (security) if available..." | tee -a "$LOG_FILE"
   if command -v unattended-upgrade >/dev/null 2>&1; then

--- a/linux/debian/system-update.sh
+++ b/linux/debian/system-update.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# system-update.sh
+# Small, safe wrapper to perform unattended security updates and package upgrades on Debian/Ubuntu.
+# - requires root (will re-run with sudo if needed)
+# - avoids running concurrently with dpkg/apt locks
+# - logs to /var/log/system-update.log (rotated by logrotate on many distros)
+
+LOG_FILE="/var/log/system-update.log"
+
+ensure_root() {
+  if [ "$(id -u)" -ne 0 ]; then
+    echo "Re-running as root using sudo..."
+    exec sudo bash "$0" "$@"
+  fi
+}
+
+wait_for_apt_lock() {
+  local tries=0
+  local max=30
+  local sleep_sec=2
+  while fuser /var/lib/dpkg/lock >/dev/null 2>&1 || fuser /var/lib/apt/lists/lock >/dev/null 2>&1 || fuser /var/cache/apt/archives/lock >/dev/null 2>&1; do
+    if [ "$tries" -ge "$max" ]; then
+      echo "Timed out waiting for apt/dpkg locks" | tee -a "$LOG_FILE"
+      return 1
+    fi
+    echo "Waiting for apt/dpkg lock to be released... (attempt $((tries+1)))" | tee -a "$LOG_FILE"
+    sleep "$sleep_sec"
+    tries=$((tries+1))
+  done
+  return 0
+}
+
+timestamp() { date --rfc-3339=seconds; }
+
+main() {
+  ensure_root
+
+  mkdir -p "$(dirname "$LOG_FILE")"
+  echo "$(timestamp) - START system-update" | tee -a "$LOG_FILE"
+
+  if ! wait_for_apt_lock; then
+    echo "Failed to acquire apt locks" | tee -a "$LOG_FILE"
+    exit 2
+  fi
+
+  echo "Running apt-get update..." | tee -a "$LOG_FILE"
+  apt-get update -y 2>&1 | tee -a "$LOG_FILE"
+
+  echo "Running unattended-upgrades (security) if available..." | tee -a "$LOG_FILE"
+  if command -v unattended-upgrade >/dev/null 2>&1; then
+    unattended-upgrade -v 2>&1 | tee -a "$LOG_FILE" || true
+  elif [ -f /usr/bin/unattended-upgrade ]; then
+    /usr/bin/unattended-upgrade -v 2>&1 | tee -a "$LOG_FILE" || true
+  else
+    echo "unattended-upgrade not installed; performing safe upgrade" | tee -a "$LOG_FILE"
+    apt-get upgrade -y 2>&1 | tee -a "$LOG_FILE" || true
+  fi
+
+  echo "Cleaning apt cache..." | tee -a "$LOG_FILE"
+  apt-get autoremove -y 2>&1 | tee -a "$LOG_FILE" || true
+  apt-get clean 2>&1 | tee -a "$LOG_FILE" || true
+
+  if [ -f /var/run/reboot-required ] || [ -f /var/run/reboot-required.pkgs ]; then
+    echo "Reboot required after updates" | tee -a "$LOG_FILE"
+  fi
+
+  echo "$(timestamp) - END system-update" | tee -a "$LOG_FILE"
+}
+
+main "$@"


### PR DESCRIPTION
- Add linux/debian/system-update.sh: safe, security-focused update script that waits for apt/dpkg locks, auto-elevates with sudo, logs to /var/log/system-update.log and reports reboot requirements.
- Add linux/debian/full-update.sh: full dist-upgrade script with non-interactive (--yes) and --reboot options, logs to /var/log/full-update.log.
- Add linux/debian/README.md: usage, scheduling recommendations, and notes about unattended-upgrades and systemd timer integration.