### PR TITLE
Add installation script for GitHub CLI

### DIFF
--- a/github/README.md
+++ b/github/README.md
@@ -1,0 +1,3 @@
+# GitHub Bash Scripts
+
+These scripts will be for completing tasks like installing the GitHub CLI or interacting with the GitHub API.

--- a/github/github-cli/gh-cli-install.sh
+++ b/github/github-cli/gh-cli-install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Script to install GitHub CLI on Debian-based systems
+
+(type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y)) \
+	&& sudo mkdir -p -m 755 /etc/apt/keyrings \
+	&& out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+	&& cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+	&& sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+	&& sudo mkdir -p -m 755 /etc/apt/sources.list.d \
+	&& echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+	&& sudo apt update \
+	&& sudo apt install gh -y


### PR DESCRIPTION
This pull request introduces initial setup for GitHub-related bash scripts, including documentation and a script to install the GitHub CLI on Debian-based systems.

Documentation:

* Added a new `github/README.md` file describing the purpose of the GitHub bash scripts for tasks such as installing the GitHub CLI and interacting with the GitHub API.

Script additions:

* Added `github/github-cli/gh-cli-install.sh`, a bash script that automates the installation of the GitHub CLI (`gh`) on Debian-based systems, including keyring setup and repository configuration.